### PR TITLE
fix bug in mobile browserstack environments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.springer</groupId>
 	<artifactId>omelet</artifactId>
-	<version>1.0.0</version>
+	<version>1.0.1</version>
 	<packaging>jar</packaging>
 	<name>omelet</name>
 	<url>https://github.com/springer-opensource/omelet</url>

--- a/src/main/java/com/springer/omelet/driver/DriverFactory.java
+++ b/src/main/java/com/springer/omelet/driver/DriverFactory.java
@@ -120,7 +120,9 @@ class DriverFactory {
 
 		// For maximizing driver windows and wait
 		if (webDriver != null) {
-			webDriver.manage().window().maximize();
+			if (this.isMobileTest == false) {
+				webDriver.manage().window().maximize();	
+			}
 			webDriver.manage().timeouts()
 					.implicitlyWait(driverTimeOut, TimeUnit.SECONDS);
 		}


### PR DESCRIPTION
- add a simple if condition to check if this is a mobile test
- only on desktop environments is a "max browser window" possible
