### PR TITLE
Make all WebDriver timeouts configurable

### DIFF
--- a/omelet-core/src/main/java/omelet/driver/DriverFactory.java
+++ b/omelet-core/src/main/java/omelet/driver/DriverFactory.java
@@ -105,10 +105,11 @@ class DriverFactory {
 			webDriver = new PhantomJSDriver(dc);
 		}
 
-		// For set driver timeout
 		if (webDriver != null) {
-			webDriver.manage().timeouts()
-					.implicitlyWait(driverTimeOut, TimeUnit.SECONDS);
+			final WebDriver.Timeouts timeouts = webDriver.manage().timeouts();
+			timeouts.implicitlyWait  (driverTimeOut, TimeUnit.SECONDS);
+			timeouts.setScriptTimeout(driverTimeOut, TimeUnit.SECONDS);
+			timeouts.pageLoadTimeout (driverTimeOut, TimeUnit.SECONDS);
 		}
 
 		if (ishiglightElementFlag) {


### PR DESCRIPTION
For now, we use one configuration to set all timeouts (implicit wait, script and page load).

Motivation: I want to be able to configure all timeouts, not only the implicit wait timeout. 